### PR TITLE
Support new VyOS build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,9 @@
 .PHONY: build configure prepare clean
 
-build: configure
-	docker run --rm -t --privileged -v $(PWD)/vyos-build:/vyos -w /vyos vyos/vyos-build:current sudo make iso
+build: prepare
+	docker run --rm -t --privileged -v $(PWD)/vyos-build:/vyos -w /vyos vyos/vyos-build:current sudo ./build-vyos-image iso --architecture amd64 --custom-apt-key ../tailscale.gpg --custom-apt-entry "deb https://pkgs.tailscale.com/stable/debian bullseye main" --custom-package "tailscale" --build-comment "VyOS with Tailscale" --build-type release --version 1.4-rolling-`date +%Y%m%d%H%M`
 	mkdir -p ./build
 	mv vyos-build/build/vyos-*.iso ./build
-
-configure: prepare
-	docker run --rm -t --privileged -v $(PWD)/vyos-build:/vyos -w /vyos vyos/vyos-build:current ./configure --architecture amd64 --custom-apt-key ./tailscale.gpg --custom-apt-entry "deb https://pkgs.tailscale.com/stable/debian bullseye main" --custom-package "tailscale" --build-comment "VyOS with Tailscale" --build-type production --version 1.4-rolling-`date +%Y%m%d%H%M`
 
 prepare:
 	cp tailscale/tailscale.gpg vyos-build/tailscale.gpg

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build configure prepare clean
 
 build: prepare
-	docker run --rm -t --privileged -v $(PWD)/vyos-build:/vyos -w /vyos vyos/vyos-build:current sudo ./build-vyos-image iso --architecture amd64 --custom-apt-key ../tailscale.gpg --custom-apt-entry "deb https://pkgs.tailscale.com/stable/debian bullseye main" --custom-package "tailscale" --build-comment "VyOS with Tailscale" --build-type release --version 1.4-rolling-`date +%Y%m%d%H%M`
+	docker run --rm -t --privileged -v $(PWD)/vyos-build:/vyos -w /vyos vyos/vyos-build@sha256:d99cf3632841a426f5718db22db2c0b49b744354b5311e2ecca94f6b1a04080a sudo ./build-vyos-image iso --architecture amd64 --custom-apt-key ../tailscale.gpg --custom-apt-entry "deb https://pkgs.tailscale.com/stable/debian bullseye main" --custom-package "tailscale" --build-comment "VyOS with Tailscale" --build-type release --version 1.4-rolling-`date +%Y%m%d%H%M`
 	mkdir -p ./build
 	mv vyos-build/build/vyos-*.iso ./build
 


### PR DESCRIPTION
In #3979b2, the `configure` script was removed and replaced with `build-vyos-image`. This does change things around a little (the intent of `configure` and `build` in the Makefile are flipped), but the change isn't too significant.

This updates to use that, along with bumping the submodule commit.

https://github.com/vyos/vyos-build/commit/3979b25dcf137600b6ba7ccd361ae78515c012e8