### PR TITLE
change state to statedir

### DIFF
--- a/tailscale/tailscaled
+++ b/tailscale/tailscaled
@@ -5,4 +5,4 @@
 PORT="41641"
 
 # Extra flags you might want to pass to tailscaled.
-FLAGS="--state=/config/tailscale/tailscaled.state"
+FLAGS="--statedir=/config/tailscale/tailscaled.state"


### PR DESCRIPTION
My [custom vyos build](https://github.com/b-/vyos-build-action) doesn't seem to stay logged into tailscale unless I use [the `--statedir` argument](https://github.com/tailscale/tailscale/commit/649f7556e89aa9d627ff799f4433f68249a1b6e6). This fixes that.